### PR TITLE
Initial support for installing ALEC via Docker Image.

### DIFF
--- a/alec/Dockerfile
+++ b/alec/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+RUN mkdir -p /plugins
+RUN VERSION=$(wget -O -  https://api.github.com/repos/OpenNMS/alec/releases/latest 2>/dev/null | grep tag_name | cut -d '"' -f 4) && \
+    wget -O /plugins/opennms-alec-plugin.kar https://github.com/OpenNMS/alec/releases/download/$VERSION/opennms-alec-plugin.kar

--- a/alec/README.md
+++ b/alec/README.md
@@ -1,0 +1,42 @@
+# ALEC Docker Image
+
+To avoid reaching GitHub every time the OpenNMS Core container starts to install ALEC, the idea is to create a place-holder container, meaning a container that has no functionality but contains the ALEC KAR file.
+
+The idea is to use this container within the `initContainers` section of the OpenNMS `StatefulSet` to copy the KAR file to the `$OPENNMS_HOME/deploy` directory at runtime.
+
+## Compilation
+
+```bash
+ALEC_VER=$(curl -s https://api.github.com/repos/OpenNMS/alec/releases/latest | grep tag_name | cut -d '"' -f 4)
+docker build -t opennms/alec:$ALEC_VER .
+docker push opennms/alec:$ALEC_VER
+```
+
+## Usage
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: onms-core
+...
+      initContainers:
+      - name: alec
+        image: opennms/alec:v1.1.1
+        imagePullPolicy: IfNotPresent
+        command: [ cp, /plugins/opennms-alec-plugin.kar, /opennms-deploy ]
+        volumeMounts:
+        - name: deploy
+          mountPath: /opennms-deploy
+...
+      containers:
+      - name: onms
+      ...
+        volumeMounts:
+        - name: deploy
+          mountPath: /opt/opennms/deploy
+...
+      volumes:
+      - name: deploy
+        emptyDir: {}
+```

--- a/opennms/scripts/onms-core-init.sh
+++ b/opennms/scripts/onms-core-init.sh
@@ -172,6 +172,7 @@ if [[ ${ENABLE_ALEC} == "true" ]]; then
   if [[ ! -e /opt/opennms/deploy/opennms-alec-plugin.kar ]] && [[ ! -e ${DEPLOY_DIR}/opennms-alec-plugin.kar ]]; then
     KAR_VER=$(curl -s https://api.github.com/repos/OpenNMS/alec/releases/latest | grep tag_name | cut -d '"' -f 4)
     KAR_URL="https://github.com/OpenNMS/alec/releases/download/${KAR_VER}/opennms-alec-plugin.kar"
+    echo "Downloading ALEC $KAR_VER from GitHub..."
     curl -LJ -o ${DEPLOY_DIR}/opennms-alec-plugin.kar ${KAR_URL} 2>/dev/null
   fi
 

--- a/opennms/scripts/onms-core-init.sh
+++ b/opennms/scripts/onms-core-init.sh
@@ -169,7 +169,7 @@ EOF
 
 # Enable ALEC standalone
 if [[ ${ENABLE_ALEC} == "true" ]]; then
-  if [[ ! -e /opt/opennms/deploy/opennms-alec-plugin.kar ]]; then
+  if [[ ! -e /opt/opennms/deploy/opennms-alec-plugin.kar ]] && [[ ! -e ${DEPLOY_DIR}/opennms-alec-plugin.kar ]]; then
     KAR_VER=$(curl -s https://api.github.com/repos/OpenNMS/alec/releases/latest | grep tag_name | cut -d '"' -f 4)
     KAR_URL="https://github.com/OpenNMS/alec/releases/download/${KAR_VER}/opennms-alec-plugin.kar"
     curl -LJ -o ${DEPLOY_DIR}/opennms-alec-plugin.kar ${KAR_URL} 2>/dev/null

--- a/opennms/templates/app-scripts.configmap.yaml
+++ b/opennms/templates/app-scripts.configmap.yaml
@@ -9,21 +9,4 @@ metadata:
   labels:
     {{- include "opennms.labels" . | nindent 4 }}
 data:
-  grafana-init.sh: |
-    {{- .Files.Get "scripts/grafana-init.sh" | nindent 4 }}
-  onms-common-init.sh: |
-    {{- .Files.Get "scripts/onms-common-init.sh" | nindent 4 }}
-  onms-core-init.sh: |
-    {{- .Files.Get "scripts/onms-core-init.sh" | nindent 4 }}
-  onms-grafana-init.sh: |
-    {{- .Files.Get "scripts/onms-grafana-init.sh" | nindent 4 }}
-  onms-post-init.sh: |
-    {{- .Files.Get "scripts/onms-post-init.sh" | nindent 4 }}
-{{- if gt ((.Values.sentinel).replicaCount|int) 0 }}
-  onms-sentinel-init.sh: |
-    {{- .Files.Get "scripts/onms-sentinel-init.sh" | nindent 4 }}
-{{- end }}
-{{- if gt (((.Values.opennms).uiServers).replicaCount|int) 0 }}
-  onms-ui-init.sh: |
-    {{- .Files.Get "scripts/onms-ui-init.sh" | nindent 4 }}
-{{- end }}
+  {{- (.Files.Glob "scripts/**").AsConfig | nindent 2 }}

--- a/opennms/templates/opennms-core.statefulset.yaml
+++ b/opennms/templates/opennms-core.statefulset.yaml
@@ -33,6 +33,15 @@ spec:
         {{- end }}
       {{- end }}
       initContainers:
+      {{- if .Values.opennms.configuration.enable_alec }}
+      - name: alec
+        image: {{ .Values.opennms.configuration.alecImage.repository }}:{{ .Values.opennms.configuration.alecImage.tag }}
+        imagePullPolicy: {{ .Values.opennms.configuration.alecImage.imagePullPolicy }}
+        command: [ cp, /plugins/opennms-alec-plugin.kar, /opennms-deploy ]
+        volumeMounts:
+        - name: deploy
+          mountPath: /opennms-deploy # Required by the init script - DEPLOY_DIR
+      {{- end }}
       # Initializes/Updates OpenNMS Configuration
       # Requires the same image/version used at runtime
       - name: init

--- a/opennms/templates/opennms-core.statefulset.yaml
+++ b/opennms/templates/opennms-core.statefulset.yaml
@@ -38,6 +38,9 @@ spec:
         image: {{ .Values.opennms.configuration.alecImage.repository }}:{{ .Values.opennms.configuration.alecImage.tag }}
         imagePullPolicy: {{ .Values.opennms.configuration.alecImage.imagePullPolicy }}
         command: [ cp, /plugins/opennms-alec-plugin.kar, /opennms-deploy ]
+        securityContext: # To guarantee ownership of the KAR file so that OpenNMS won't complain.
+          runAsUser: 10001
+          runAsGroup: 10001
         volumeMounts:
         - name: deploy
           mountPath: /opennms-deploy # Required by the init script - DEPLOY_DIR

--- a/opennms/values.yaml
+++ b/opennms/values.yaml
@@ -108,7 +108,7 @@ opennms:
     alecImage:
       repository: opennms/alec
       pullPolicy: IfNotPresent
-      tag: 'latest'
+      tag: v1.1.1
     database: # Access to the OpenNMS database
       username: opennms
       password: 0p3nNM5

--- a/opennms/values.yaml
+++ b/opennms/values.yaml
@@ -6,7 +6,7 @@
 timezone: America/New_York
 domain: example.com # The common domain for the Ingress resource.
 storageClass: onms-share # The name of the StorageClass that allows ReadWriteMany for RRDs and Core configuration (when using dedicated UI instances).
-opennmsVersion: '29.0.5'
+opennmsVersion: '29.0.6'
 
 # Optionally specify an array of imagePullSecrets.
 # Secrets must be manually created in the namespace.
@@ -105,6 +105,10 @@ opennms:
     - RRA:AVERAGE:0.5:288:366
     - RRA:MAX:0.5:288:366
     - RRA:MIN:0.5:288:366
+    alecImage:
+      repository: opennms/alec
+      pullPolicy: IfNotPresent
+      tag: 'latest'
     database: # Access to the OpenNMS database
       username: opennms
       password: 0p3nNM5


### PR DESCRIPTION
The solution was tested using Minikube and worked flawlessly. I added a message when it would use GitHub to download the KAR. If you don't see that message, it is because the `initContainer` for ALEC worked as expected.

I pushed `opennms/alec:v1.1.1` to DockerHub to merge the PR and be 100% functional. If someone decides to place it somewhere else, we can change the default on `values.xml` (which you can do at runtime if you use a Private Repository).

As a bonus, the `app-scripts` was updated to make it more generic (i.e., allowing the ability to add any arbitrary file to the `scripts` directory).