### PR TITLE
Tweaks for the existing Horizon 29 version so it will run again and in minikube

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ For example, when deploying the Helm Chart names `acme` (remember about the rule
 - OpenNMS Core: `onms-core.acme.k8s.agalue.net`
 - Grafana: `grafana.acme.k8s.agalue.net`
 
+If you get a certificate error with Chrome in a local cluster because you don't have a valid certificate, see [thisisunsafe - Bypassing chrome security warnings](https://cybercafe.dev/thisisunsafe-bypassing-chrome-security-warnings/).
+
+If you get a too many redirects error, try putting the path `/opennms/login.jsp` at the end of the OpenNMS UI URL to login. You might be running into problem related to [NMS-13901](https://issues.opennms.org/browse/NMS-13901).
+
 To customize behavior, you could pass custom annotations via `ingress.annotations` when deploying the Helm Chart.
 
 Please note that it is expected to have [cert-manager](https://cert-manager.io/docs/) deployed on your Kubernetes cluster as that would be used to manage the certificates (configured via `ingress.certManager.clusterIssuer`).

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ For instance, for macOS:
 ```bash
 DOMAIN="k8s.agalue.net"
 
+sudo mkdir -p /etc/resolver
 cat <<EOF | sudo tee /etc/resolver/$DOMAIN
 domain $DOMAIN
 nameserver $(minikube ip)

--- a/README.md
+++ b/README.md
@@ -300,7 +300,6 @@ Start Minikube:
 
 ```bash
 minikube start --cpus=4 --memory=24g \
-  --cni=calico \
   --addons=ingress \
   --addons=ingress-dns \
   --addons=metrics-server \

--- a/create-storageclass.sh
+++ b/create-storageclass.sh
@@ -3,7 +3,8 @@
 #
 # A StorageClass is a cluster-level resource. It must be created once.
 
-set -e
+set -euo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
 environment=${1}
 storageclass=${2}

--- a/dependencies/elasticsearch.yaml
+++ b/dependencies/elasticsearch.yaml
@@ -29,7 +29,7 @@ spec:
         - name: onms-plugin
           image: busybox
           command: [ sh, -c ]
-          args: [ "wget $(PLUGIN_URL) && unzip elasticsearch-drift-plugin-$(PLUGIN_VERSION).zip -d /plugin/" ]
+          args: [ "wget $(PLUGIN_URL) && unzip -o elasticsearch-drift-plugin-$(PLUGIN_VERSION).zip -d /plugin/" ]
           env:
             - name: PLUGIN_VERSION # Must match the chosen Elasticsearch version
               value: '7.6.2'

--- a/opennms/values.yaml
+++ b/opennms/values.yaml
@@ -6,7 +6,7 @@
 timezone: America/New_York
 domain: example.com # The common domain for the Ingress resource.
 storageClass: onms-share # The name of the StorageClass that allows ReadWriteMany for RRDs and Core configuration (when using dedicated UI instances).
-opennmsVersion: '29.0.6'
+opennmsVersion: '29.0.11'
 
 # Optionally specify an array of imagePullSecrets.
 # Secrets must be manually created in the namespace.

--- a/start-aks.sh
+++ b/start-aks.sh
@@ -3,7 +3,8 @@
 #
 # WARNING: For testing purposes only
 
-set -e
+set -euo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
 for cmd in "az" "kubectl"; do
   type $cmd >/dev/null 2>&1 || { echo >&2 "$cmd required but it's not installed; aborting."; exit 1; }

--- a/start-dependencies.sh
+++ b/start-dependencies.sh
@@ -36,7 +36,7 @@ helm upgrade --install cert-manager jetstack/cert-manager \
   --namespace cert-manager --create-namespace --set installCRDs=true --wait
 kubectl apply -f ca -n cert-manager
 
-# Create a namespace for all the dependencies
+# Create a namespace for most of the dependencies except for cert-manager (above), and the postgres and elastic operators (added below).
 kubectl create namespace $NAMESPACE
 
 # Install Grafana Loki

--- a/start-dependencies.sh
+++ b/start-dependencies.sh
@@ -3,7 +3,8 @@
 #
 # WARNING: For testing purposes only
 
-set -e
+set -euo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
 for cmd in "kubectl" "helm" "keytool"; do
   type $cmd >/dev/null 2>&1 || { echo >&2 "$cmd required but it's not installed; aborting."; exit 1; }

--- a/start-dependencies.sh
+++ b/start-dependencies.sh
@@ -45,6 +45,7 @@ helm upgrade --install loki --namespace=$NAMESPACE \
   --set "fullnameOverride=loki" \
   --set "gateway.enabled=false" \
   --set "loki.storage.type=filesystem" \
+  --set "loki.rulerConfig.storage.type=local" \
   --set "monitoring.selfMonitoring.enabled=false" \
   --set "monitoring.selfMonitoring.grafanaAgent.installOperator=false" \
   --set "persistence.enabled=true" \

--- a/start-gke.sh
+++ b/start-gke.sh
@@ -3,7 +3,8 @@
 #
 # WARNING: For testing purposes only
 
-set -e
+set -euo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
 for cmd in "gcloud" "kubectl"; do
   type $cmd >/dev/null 2>&1 || { echo >&2 "$cmd required but it's not installed; aborting."; exit 1; }

--- a/start-minion.sh
+++ b/start-minion.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # @author Alejandro Galue <agalue@opennms.com>
 
-set -e
+set -euo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
 type docker >/dev/null 2>&1 || { echo >&2 "docker required but it's not installed; aborting."; exit 1; }
 


### PR DESCRIPTION
Please see individual commits.

The few that I want to highlight are:
* [Add details for start-dependencies.sh and create-storageclass.sh](https://github.com/opennms-forge/onms-k8s-poc/commit/10c7b09f5a1f3d21d67ad279c65557568d40c125)
* [Only start 1 loki read and write replica](https://github.com/opennms-forge/onms-k8s-poc/commit/910533b589ab1720e714b96061db0d4306dc498e) 
* [Removing Calico for now since I haven't had good luck with it](https://github.com/opennms-forge/onms-k8s-poc/pull/5/commits/2b5b994888ddebbac2072db0b56140b89a3d0886)

I think everything else is pretty straightforward.