### PR TITLE
NMS-15655: k8s: Make "rollme" annotation in the onms deployment optional

### DIFF
--- a/opennms/templates/NOTES.txt
+++ b/opennms/templates/NOTES.txt
@@ -28,3 +28,10 @@ To learn more about the release, try:
 $ helm status {{ .Release.Name }}
 $ helm get all {{ .Release.Name }}
 $ kubectl get all -n {{ .Release.Name }}
+
+{{- if not .Values.opennms.configuration.alwaysRollDeployment }}
+
+If OpenNMS needs to be restarted to apply configuration changes, you'll need to restart it, e.g.:
+    kubectl rollout restart -n {{ .Release.Name }} statefulset/onms-core
+{{- end }}
+

--- a/opennms/templates/opennms-core.statefulset.yaml
+++ b/opennms/templates/opennms-core.statefulset.yaml
@@ -23,7 +23,9 @@ spec:
         app: onms-core
         {{- include "opennms.selectorLabels" . | nindent 8 }}
       annotations:
+      {{- if .Values.opennms.configuration.alwaysRollDeployment }}
         rollme: {{ randAlphaNum 5 | quote }}
+      {{- end }}
     spec:
       securityContext:
         fsGroup: 10001 # Required for Google Fileshare (might impact performance)

--- a/opennms/values.yaml
+++ b/opennms/values.yaml
@@ -104,6 +104,7 @@ opennms:
       cpu: '2'
       memory: 4Gi
   configuration:
+    alwaysRollDeployment: true
     enable_alec: true    # See alecImage below for how the KAR is retrieved
     enable_cortex: false # See cortexTssImage below for how the KAR is retrieved
     enable_tss_dual_write: false


### PR DESCRIPTION
Adding alwaysRollDeployment option to allow the user to control the rollme feature in opennms-core.
